### PR TITLE
Update HOW-TO.md

### DIFF
--- a/development/HOW-TO.md
+++ b/development/HOW-TO.md
@@ -22,7 +22,7 @@ docker-compose exec app bash
 ## Enter the Rails console
 * Enter the app shell
 ```
-rails c
+bin/rails c
 exit
 ```
 


### PR DESCRIPTION
When executing: docker-compose exec app bash
and then: rails c 
this message appears: bash: rails: command not found but when executing: bin/rails c
(the error Error loading RC file '/usr/local/rvm/rubies/ruby-3.3.0/.irbrc': shows but apparently causes no problems)
this console appears: irb(main):001>
and it's possible to create users.

Including "bin/" to the line is a suggestion for those who encounter this problem that was a bit of a headache (for a newbie).
(I don't know if it's just a linux issue)
os: lmde 6