### PR TITLE
align docker compose with rest of documentation

### DIFF
--- a/development/HOW-TO.md
+++ b/development/HOW-TO.md
@@ -43,7 +43,7 @@ This includes an admin and a non-admin user, which are admin@example.com and use
 ### One-line using docker
 From the taxonworks directory:
 ```
-docker-compose exec app bundle exec rails db:seed
+docker compose exec app bundle exec rails db:seed
 ```
 
 ## Creating a new task


### PR DESCRIPTION
https://github.com/SpeciesFileGroup/install_taxonworks/blob/7db537c6a9b4f16d9712d86d15fbcb5edfe127eb/development/docker/README.md has the following text

> Instructions below refer to running docker compose, but if you're running an older version of docker you may need to use docker-compose instead.

This aligns the docker compose command to agree with that premise