### PR TITLE
Update contributing.md

### DIFF
--- a/docs/develop/Code/contributing.md
+++ b/docs/develop/Code/contributing.md
@@ -4,7 +4,7 @@ sidebarPosition: 5
 
 # Contributing
 
-See also [Contributing](/CContributing/) for non-code contributions.
+See also [Contributing](/Contributing/) for non-code contributions.
 
 
 - Make a new branch off of the development branch (see [Fork](https://help.github.com/articles/fork-a-repo/))


### PR DESCRIPTION
typo in URL

Also @mjy this link https://docs.taxonworks.org/Develop/Install/ produces 404